### PR TITLE
remove redundant mirrors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@
 
 buildscript {
     repositories {
-        maven { url "https://maven.aliyun.com/repository/central" }
-        maven { url "https://maven.aliyun.com/repository/google" }
         mavenCentral()
         google()
     }
@@ -21,14 +19,11 @@ buildscript {
 // google() repository beginning with version 3.2 of the Android Gradle Plugin
 allprojects {
     repositories {
-        maven { url "https://maven.aliyun.com/repository/central" }
-        maven { url "https://maven.aliyun.com/repository/google" }
         mavenCentral()
         google()
     }
 }
 
 repositories {
-    maven { url "https://maven.aliyun.com/repository/central" }
     mavenCentral()
 }


### PR DESCRIPTION

## Introduction

It seems that these repos are accessible from China mainland and Gradle proxies and be added if necessary.

## Background

After some tests, these mirrors are found to be redundant, so we'll remove them to prevent possible build failure in GitHub Actions.

## Real robot tests

- [x] No real robot tests have been performed.

