### PR TITLE
fix the java job name to match the real version used

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 17
+    - name: set up JDK 21
       uses: actions/setup-java@v4
       with:
         java-version: '21'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew --debug build


### PR DESCRIPTION
## Introduction

Fix the job name of `setup-java` to match the real Java version used (namely 21).

## Real robot tests

- [ ] Real robot tests have been performed.
- [x] No real robot tests have been performed.

